### PR TITLE
Template refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@ pkg/
 .internal_test_app/*
 
 node_modules
-app/assets/javascripts/spotlight/webpack_bundle.js
-app/assets/javascripts/spotlight/webpack_bundle.js.map
+lib/generators/spotlight/templates/webpack_bundle.js.map
 .env*.local
 .vagrant
 ubuntu*.log

--- a/app/assets/javascripts/spotlight/spotlight.js
+++ b/app/assets/javascripts/spotlight/spotlight.js
@@ -14,10 +14,9 @@ Spotlight = function() {
 }();
 
 Blacklight.onLoad(function() {
-  Spotlight.activate();
+	Spotlight.activate();
 });
 
 Spotlight.onLoad(function(){
-  SpotlightNestable.init();
+	SpotlightNestable.init();
 });
-

--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -31,7 +31,7 @@
     <!--[if lt IE 9]>
       <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-		<%= javascript_include_tag "application" %>	
+		<%= javascript_include_tag "application" %>
 	</head>
   <body class="<%= render_body_class %>">
   <%= render partial: 'shared/header_navbar' %>
@@ -52,13 +52,8 @@
   <%= render :partial => 'shared/footer' %>
 
   <!-- Load JavaScript last so that the rest of the page can start rendering -->
-	<% if Rails.env.development? %>
-		<!-- FIXME: Don't force developers to run server on localhost:8080 -->
-		<script src="//localhost:8080/webpack_bundle.js"></script>
-	<% else %>
-		<!-- FIXME: Put the webpack bundle on a CDN as part of deployment to production -->
-		<%= javascript_include_tag "spotlight/webpack_bundle" %>
-	<% end %>
+	<!-- FIXME: Put the webpack bundle on a CDN as part of deployment to production -->
+	<%= javascript_include_tag "webpack_bundle" %>
 	<%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
   </body>
 </html>

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -59,6 +59,10 @@ module Spotlight
       copy_file 'spotlight.js', 'app/assets/javascripts/spotlight.js'
     end
 
+		def build_webpack_assets
+
+		end
+
     def add_theme_images
       empty_directory 'app/assets/images/spotlight/themes'
       copy_file 'default_preview.png', 'app/assets/images/spotlight/themes/default_preview.png'

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -57,11 +57,8 @@ module Spotlight
       copy_file 'spotlight.scss', 'app/assets/stylesheets/spotlight.scss'
       copy_file 'harvard.css', 'app/assets/stylesheets/harvard.css'
       copy_file 'spotlight.js', 'app/assets/javascripts/spotlight.js'
+			copy_file 'webpack_bundle.js', 'app/assets/javascripts/webpack_bundle.js'
     end
-
-		def build_webpack_assets
-
-		end
 
     def add_theme_images
       empty_directory 'app/assets/images/spotlight/themes'

--- a/lib/generators/spotlight/templates/config/initializers/assets.rb
+++ b/lib/generators/spotlight/templates/config/initializers/assets.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.precompile += %w( spotlight/webpack_bundle.js )
+Rails.application.config.assets.precompile += %w( webpack_bundle.js )

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "prettier": "prettier app/web/**/*.js",
     "prettier:write": "prettier --write app/web/**/*.js",
     "start": "yarn run watch:js",
-    "watch:js": "NODE_ENV=development webpack-dev-server --config ./webpack.config.js --mode development"
-  }
+    "watch:js": "NODE_ENV=development webpack --watch --config ./webpack.config.js --mode development"
+  },
+	"precommit": "build"
 }

--- a/template.rb
+++ b/template.rb
@@ -7,7 +7,7 @@ spotlight_options = ENV.fetch('SPOTLIGHT_INSTALL_OPTIONS', DEFAULT_SPOTLIGHT_OPT
 
 # Add gem dependencies to the application
 gem 'blacklight', ' ~> 6.0'
-gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'harvard-library/spotlight', :branch => 'harvard_development' }
+gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'ArchimedesDigital/spotlight', :branch => 'template-refactor' }
 
 Bundler.with_clean_env do
   run 'bundle install'

--- a/template.rb
+++ b/template.rb
@@ -7,7 +7,7 @@ spotlight_options = ENV.fetch('SPOTLIGHT_INSTALL_OPTIONS', DEFAULT_SPOTLIGHT_OPT
 
 # Add gem dependencies to the application
 gem 'blacklight', ' ~> 6.0'
-gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'ArchimedesDigital/spotlight', :branch => 'template-refactor' }
+gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'harvard-library/spotlight', :branch => 'harvard_development_archimedes' }
 
 Bundler.with_clean_env do
   run 'bundle install'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,10 +68,7 @@ function getClientEnvironment() {
   return stringified;
 }
 
-const entry = NODE_ENV === 'development' ? [
-	require.resolve('react-dev-utils/webpackHotDevClient'),
-	'./app/web/index.js'
-] : ['./app/web/index.js'];
+const entry = [`${paths.appSrc}/index.js`];
 
 module.exports = {
 	devtool: NODE_ENV === 'development' && 'cheap-module-source-map',
@@ -199,9 +196,7 @@ module.exports = {
 	output: {
 		chunkFilename: '[name].chunk.js',
 		filename: 'webpack_bundle.js',
-		path: path.resolve(__dirname, 'app/assets/javascripts/spotlight'),
-		pathinfo: true,
-		publicPath: "/",
+		path: path.resolve('lib/generators/spotlight/templates')
 	},
 	performance: {
 		hints: false,
@@ -216,8 +211,5 @@ module.exports = {
 	],
 	resolve: {
 		extensions: ['*', '.js', '.jsx']
-	},
-	devServer: {
-		contentBase: path.resolve(__dirname, 'app/assets/javascripts/spotlight')
 	}
 };


### PR DESCRIPTION
The main change introduced by this commit is moving the webpack bundle from under `app/web/` to `lib/generators/spotlight/templates/` and copying the bundle over to the host app's assets. It's a minor change in the long run, but it required a bit of experimentation on the development side.

It would be nice to configure the repository so that we don't have to commit the bundled JavaScript but could instead build it once the gem is installed. This goal shouldn't be too hard to achieve -- I think we could recursively `copy_file` on files in `app/web/` in `lib/generators/spotlight/install_generator.rb` and then build those copies through a `generator` task -- but in the interest of getting eyes on these changes ASAP, I wanted to push this code as is.